### PR TITLE
Add customizable hotkey to auto clicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Simple auto clicker using Python.
 ## Requirements
 - Python 3.x
 - `pyautogui` package (`pip install pyautogui`)
+- `pynput` package (`pip install pynput`)
 
 ## Usage
 Run the autoclicker script:
@@ -13,5 +14,7 @@ Run the autoclicker script:
 python autoclicker.py
 ```
 
-A small window will appear allowing you to set the click interval (in seconds).
-Press `Start` to begin clicking and `Stop` to end.
+A small window will appear allowing you to set the click interval (in seconds)
+and choose a hotkey for toggling the clicker. Press `Start` to begin clicking
+and `Stop` to end. You can also press your chosen hotkey (default `F6`) to
+start or stop the clicker at any time.

--- a/autoclicker.py
+++ b/autoclicker.py
@@ -5,6 +5,10 @@ try:
     import pyautogui
 except ImportError:
     raise SystemExit('pyautogui is required. Install with `pip install pyautogui`.')
+try:
+    from pynput import keyboard
+except ImportError:
+    raise SystemExit('pynput is required. Install with `pip install pynput`.')
 
 class AutoClicker:
     def __init__(self, master):
@@ -12,24 +16,51 @@ class AutoClicker:
         master.title("Simple Auto Clicker")
 
         self.interval_var = tk.DoubleVar(value=1.0)
+        self.hotkey_var = tk.StringVar(value="F6")
 
         tk.Label(master, text="Interval (seconds):").grid(row=0, column=0, padx=5, pady=5)
         self.interval_entry = tk.Entry(master, textvariable=self.interval_var)
         self.interval_entry.grid(row=0, column=1, padx=5, pady=5)
 
+        tk.Label(master, text="Hotkey:").grid(row=1, column=0, padx=5, pady=5)
+        self.hotkey_entry = tk.Entry(master, textvariable=self.hotkey_var)
+        self.hotkey_entry.grid(row=1, column=1, padx=5, pady=5)
+
         self.start_button = tk.Button(master, text="Start", command=self.start_clicking)
-        self.start_button.grid(row=1, column=0, padx=5, pady=5)
+        self.start_button.grid(row=2, column=0, padx=5, pady=5)
 
         self.stop_button = tk.Button(master, text="Stop", command=self.stop_clicking, state=tk.DISABLED)
-        self.stop_button.grid(row=1, column=1, padx=5, pady=5)
+        self.stop_button.grid(row=2, column=1, padx=5, pady=5)
 
         self.clicking = False
         self.thread = None
+        self.listener = None
+
+        self.hotkey_var.trace_add("write", lambda *args: self.setup_hotkey_listener())
+        self.setup_hotkey_listener()
 
     def click_loop(self):
         while self.clicking:
             pyautogui.click()
             time.sleep(max(self.interval_var.get(), 0.001))
+
+    def setup_hotkey_listener(self):
+        hotkey = self.hotkey_var.get().strip()
+        if not hotkey:
+            return
+        if self.listener:
+            self.listener.stop()
+        self.listener = keyboard.GlobalHotKeys({hotkey: self.toggle_clicking})
+        self.listener.start()
+
+    def toggle_clicking(self):
+        self.master.after(0, self._toggle_clicking)
+
+    def _toggle_clicking(self):
+        if self.clicking:
+            self.stop_clicking()
+        else:
+            self.start_clicking()
 
     def start_clicking(self):
         if not self.clicking:
@@ -45,7 +76,14 @@ class AutoClicker:
             self.start_button.config(state=tk.NORMAL)
             self.stop_button.config(state=tk.DISABLED)
 
+    def on_close(self):
+        if self.listener:
+            self.listener.stop()
+            self.listener = None
+        self.master.destroy()
+
 if __name__ == "__main__":
     root = tk.Tk()
     app = AutoClicker(root)
+    root.protocol("WM_DELETE_WINDOW", app.on_close)
     root.mainloop()


### PR DESCRIPTION
## Summary
- allow user-defined hotkey for starting/stopping clicks
- use `pynput` for global hotkey listening
- stop listener when application closes
- document new feature and dependency

## Testing
- `python -m py_compile autoclicker.py`


------
https://chatgpt.com/codex/tasks/task_e_6842d988c3208324993b5c946990af79